### PR TITLE
fix missing older_available property in request

### DIFF
--- a/yampy/apis/messages.py
+++ b/yampy/apis/messages.py
@@ -301,7 +301,11 @@ class MessagesAPI(object):
                 limit=limit,
                 threaded=threaded,
             ))
-            return (messages['meta']['older_available'],
+            try:
+                older_available = messages['meta']['older_available']
+            except KeyError:
+                older_available = False
+            return (older_available,
                     messages,
                     messages['messages'][-1:][0]['id'])
         are_more = True


### PR DESCRIPTION
This happens when newer_than is used with a very recent message id