### PR TITLE
Add support for file attachments when creating messages

### DIFF
--- a/yampy/apis/messages.py
+++ b/yampy/apis/messages.py
@@ -204,7 +204,7 @@ class MessagesAPI(object):
 
     def create(self, body, group_id=None, replied_to_id=None,
                direct_to_id=None, topics=[], broadcast=None,
-               open_graph_object={}):
+               open_graph_object={}, files=None):
         """
         Posts a new message to Yammer. Returns the new message in the same
         format as the various message listing methods (:meth:`all`,
@@ -231,6 +231,9 @@ class MessagesAPI(object):
            * ``site_name``
            * ``fetch`` (set to ``True`` to derive other OG data from the URL)
            * ``meta`` (for custom structured data)
+        * ``files`` -- A dict containing files to attach to the message.
+          the keys shold be ``attachment1`` to ``attachment20``.  The values
+          should be open file objects
         """
         if len(topics) > 20:
             raise TooManyTopicsError("Too many topics, the maximum is 20")
@@ -238,14 +241,15 @@ class MessagesAPI(object):
         if len(open_graph_object) > 0 and "url" not in open_graph_object:
             raise InvalidOpenGraphObjectError("URL is required")
 
-        return self._client.post("/messages", **self._argument_converter(
-            body=body,
-            group_id=group_id,
-            replied_to_id=replied_to_id,
-            direct_to_id=direct_to_id,
-            topic=topics,
-            broadcast=broadcast,
-            og=open_graph_object,
+        return self._client.post("/messages", files=files,
+            **self._argument_converter(
+                body=body,
+                group_id=group_id,
+                replied_to_id=replied_to_id,
+                direct_to_id=direct_to_id,
+                topic=topics,
+                broadcast=broadcast,
+                og=open_graph_object,
         ))
 
     def delete(self, message_id):

--- a/yampy/client.py
+++ b/yampy/client.py
@@ -74,12 +74,16 @@ class Client(object):
         return self._request("delete", path, **kwargs)
 
     def _request(self, method, path, **kwargs):
+        if 'files' in kwargs:
+            kwargs = kwargs.copy()
+        files = kwargs.pop('files', None)
         response = requests.request(
             method=method,
             url=self._build_url(path),
             headers=self._build_headers(),
             proxies=self._proxies,
             params=kwargs,
+            files=files,
         )
         return self._parse_response(response)
 


### PR DESCRIPTION
Yammer supports adding attachments when creating messages using multi-part forms:
https://developer.yammer.com/docs/messages-json-post

This patch adds support for the simple attachment method.  There is also a pending_attachment method, but I don't have a need for that, and it isn't supported by this patch.
